### PR TITLE
Fix routing issue for "/joinold" route

### DIFF
--- a/Day 14 (google meet )/server.js
+++ b/Day 14 (google meet )/server.js
@@ -32,7 +32,7 @@ app.get("/join", (req, res) => {
 app.get("/joinold", (req, res) => {
     res.redirect(
         url.format({
-            pathname: req.query.meeting_id,
+            pathname:`/join/${req.query.meeting_id}`,
             query: req.query,
         })
     );


### PR DESCRIPTION
I have fixed the routing issue that was causing a "Cannot GET /" error by updating the path of the "/joinold" route. The new route redirects users to the "/join/:meeting_id" .This ensures that users are able to join existing meetings by entering the correct meeting id.